### PR TITLE
update build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ env:
     - BINARYBUILDER_AUTOMATIC_APPLE=true
 sudo: required
 
+jobs:
+  include:
+    - stage: regenerate build.jl
+      script: julia build_tarballs.jl --only-buildjl
+      if: tag IS present
+
 # Before anything else, get the latest versions of things
 before_script:
   - julia -e 'Pkg.clone("https://github.com/JuliaPackaging/BinaryProvider.jl")'

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -2,7 +2,7 @@ using BinaryBuilder
 
 # These are the platforms built inside the wizard
 platforms = [
-    BinaryProvider.Linux(:i686, :glibc),
+  BinaryProvider.Linux(:i686, :glibc),
   BinaryProvider.Linux(:x86_64, :glibc),
   BinaryProvider.Linux(:aarch64, :glibc),
   BinaryProvider.Linux(:armv7l, :glibc),
@@ -12,14 +12,6 @@ platforms = [
   BinaryProvider.Windows(:x86_64)
 ]
 
-
-# If the user passed in a platform (or a few, comma-separated) on the
-# command-line, use that instead of our default platforms
-if length(ARGS) > 0
-    platforms = platform_key.(split(ARGS[1], ","))
-end
-info("Building for $(join(triplet.(platforms), ", "))")
-
 # Collection of sources required to build openspecfun
 sources = [
     "https://github.com/JuliaLang/openspecfun/archive/v0.5.3.tar.gz" =>
@@ -27,26 +19,15 @@ sources = [
 ]
 
 script = raw"""
-cd $WORKSPACE/srcdir
-cd openspecfun-0.5.3/
+cd $WORKSPACE/srcdir/openspecfun-0.5.3
 make
-mkdir ../../destdir/lib/
-cp libopenspecfun.* ../../destdir/lib/
-
+mkpath $prefix/lib
+cp libopenspecfun.* $prefix/lib
 """
 
-products = prefix -> [
-    LibraryProduct(prefix,"libopenspecfun"),
-    LibraryProduct(prefix,"libopenspecfun"),
+products(prefix) = [
     LibraryProduct(prefix,"libopenspecfun")
 ]
 
-
 # Build the given platforms using the given sources
-hashes = autobuild(pwd(), "openspecfun", platforms, sources, script, products)
-
-if !isempty(get(ENV,"TRAVIS_TAG",""))
-    print_buildjl(pwd(), products, hashes,
-        "https://github.com/KristofferC/OpenspecfunBuilder/releases/download/$(ENV["TRAVIS_TAG"])")
-end
-
+hashes = build_tarballs(ARGS, "openspecfun", sources, script, platforms, products, [])

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -1,16 +1,9 @@
 using BinaryBuilder
 
-# These are the platforms built inside the wizard
-platforms = [
-  BinaryProvider.Linux(:i686, :glibc),
-  BinaryProvider.Linux(:x86_64, :glibc),
-  BinaryProvider.Linux(:aarch64, :glibc),
-  BinaryProvider.Linux(:armv7l, :glibc),
-  BinaryProvider.Linux(:powerpc64le, :glibc),
-  BinaryProvider.MacOS(),
-  BinaryProvider.Windows(:i686),
-  BinaryProvider.Windows(:x86_64)
-]
+platforms = supported_platforms()
+
+# FreeBSD doesn't work yet: BinaryBuilder.jl#277
+platforms = filter!(p -> !(p isa FreeBSD), platforms)
 
 # Collection of sources required to build openspecfun
 sources = [
@@ -19,10 +12,10 @@ sources = [
 ]
 
 script = raw"""
-cd $WORKSPACE/srcdir/openspecfun-0.5.3
-make
-mkpath $prefix/lib
-cp libopenspecfun.* $prefix/lib
+cd $WORKSPACE/srcdir/openspecfun-*
+make CC="$CC" CXX="$CXX" FC="$FC" -j${nproc}
+mkdir -p $libdir
+cp libopenspecfun*.${dlext}* $libdir
 """
 
 products(prefix) = [


### PR DESCRIPTION
For some reason the build script was listing the `LibraryProduct` three times.  It was also calling `autobuild` rather than `build_tarballs`, and manually doing a bunch of the things that `build_tarballs` does for you — was this from a really old version of the wizard?

Various other updates from #6 etcetera.